### PR TITLE
Adding code scan

### DIFF
--- a/.github/workflows/trivy_scan.yaml
+++ b/.github/workflows/trivy_scan.yaml
@@ -16,6 +16,10 @@ jobs:
         with:
           cache: true
 
+      # TODO - Add a step to separate files into release directories without actually
+      #       creating the release tarballs and zips, requires modifying the release.sh script
+      #       to accept a flag to only separate files into directories
+
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@0.29.0
         with:

--- a/.github/workflows/trivy_scan.yaml
+++ b/.github/workflows/trivy_scan.yaml
@@ -1,0 +1,32 @@
+name: Trivy Vulnerabilities Scan
+
+on:
+  pull_request:
+
+jobs:
+  trivy-vuln-scan:
+    name: Running Trivy Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Manual Trivy Setup
+        uses: aquasecurity/setup-trivy@v0.2.2
+        with:
+          cache: true
+
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@0.29.0
+        with:
+          skip-setup-trivy: true
+          scan-type: "fs"
+          scanners: "misconfig"
+          severity: "CRITICAL,HIGH,MEDIUM"
+          format: "sarif"
+          output: "trivy-results.sarif"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "trivy-results.sarif"

--- a/.github/workflows/trivy_scan.yaml
+++ b/.github/workflows/trivy_scan.yaml
@@ -11,26 +11,43 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Compose templates to scan
+        run: ./compose.sh
+
       - name: Manual Trivy Setup
         uses: aquasecurity/setup-trivy@v0.2.2
         with:
           cache: true
-
-      # TODO - Add a step to separate files into release directories without actually
-      #       creating the release tarballs and zips, requires modifying the release.sh script
-      #       to accept a flag to only separate files into directories
 
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@0.29.0
         with:
           skip-setup-trivy: true
           scan-type: "fs"
+          scan-ref: "magic_castle-scan"
           scanners: "misconfig"
           severity: "CRITICAL,HIGH,MEDIUM"
-          format: "sarif"
-          output: "trivy-results.sarif"
+          format: "json"
+          output: "trivy-results.json"
+
+      - name: Convert Trivy JSON output to SARIF
+        run: trivy convert --format sarif --output trivy-results.sarif trivy-results.json
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: "trivy-results.sarif"
+
+      - name: Publish Trivy Output to Summary
+        run: |
+          if [[ -s trivy-results.json ]]; then
+          {
+            echo "### Security Output"
+            echo "<details><summary>Click to expand</summary>"
+            echo ""
+            echo '```terraform'
+            cat trivy-results.json
+            echo '```'
+            echo "</details>"
+            } >> $GITHUB_STEP_SUMMARY
+            fi

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ releases/
 *dev/
 .terraform.lock.hcl
 site/
+*-scan/

--- a/compose.sh
+++ b/compose.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -e
+usage() {
+    echo "Usage: $0 [-c CLOUD...]"
+    echo ""
+    echo "  -c CLOUD...     Specify the cloud providers to include in the release"
+}
+
+CLOUD=(aws azure gcp openstack ovh)
+
+while getopts "c:" opt; do
+    case "$opt" in
+        c) 
+            if [ -z "$OPTARG" ] || [[ "$OPTARG" = -* ]]; then
+                echo "Error: the -c flag requires an argument"
+                usage
+                exit 2
+            fi
+            CLOUD=($OPTARG)
+            shift $((OPTIND-1))
+            while [ "$1" != "" ] && [[ "$1" != -* ]]; do
+                CLOUD+=("$1")
+                shift
+            done
+            OPTIND=$((OPTIND-1))
+            ;;
+        *)  usage
+            exit 2
+            ;;
+    esac
+done
+
+# Define sed_i function for in-place editing
+if [ "$(uname)" == "Linux" ]; then
+    sed_i () {
+        sed -i "$@"
+    }
+elif [ "$(uname)" == "Darwin" ]; then
+    sed_i () {
+        sed -i "" "$@"
+    }
+fi
+
+VERSION=scan
+
+# Create top level folder for scan
+FOLDER=magic_castle-$VERSION
+mkdir -p $FOLDER
+
+for provider in "${CLOUD[@]}"; do
+    # Create folder for each provider
+    cur_folder=$FOLDER/magic_castle-$provider-$VERSION
+    mkdir -p $cur_folder
+    # Copy files
+    cp -RfL common $cur_folder/
+    rm $cur_folder/common/{variables,outputs}.tf
+    cp -RfL dns $cur_folder/
+    cp -RfL $provider $cur_folder/
+    mv $cur_folder/$provider/README.md $cur_folder
+    cp LICENSE $cur_folder
+    # In module $provider, replace source and config_version
+    cp -fL examples/$provider/main.tf $cur_folder
+    sed_i 's;git::https://github.com/ComputeCanada/magic_castle.git//;./;g' $cur_folder/main.tf
+    sed_i "s;\"main\";\"$VERSION\";" $cur_folder/main.tf
+
+    # Editing main.tf so that all modules are scanned
+    cd $cur_folder
+    # Make sure only one module is named "dns"
+    sed_i '1,/dns/s/dns/cloudflare/' main.tf
+    # Uncomment DNS modules
+    sed_i 's/^#\ //g' main.tf
+    cd -
+
+    # Recreate a new unmodified main.tf
+    cp -fL examples/$provider/main.tf $cur_folder
+    # In module $provider, replace source and config_version
+    sed_i 's;git::https://github.com/ComputeCanada/magic_castle.git//;./;g' $cur_folder/main.tf
+    sed_i "s;\"main\";\"$VERSION\";" $cur_folder/main.tf
+done
+rm -rf $TMPDIR
+
+


### PR DESCRIPTION
# Content

- PR #1 
- PR #2 

# Changes

## Trivy scan

This new workflow configures [Trivy](https://trivy.dev/latest/), a static code analysis tool for IaC codebase and more. The misconfigurations reported are based of the [Aqua vulnerability database](https://avd.aquasec.com/).

## Scanning process

The `compose.sh` script creates temporary directories grouped by provider so that Trivy can scan them individually. The reason for this is scanning the repo as is will create duplicates in the results because it contains symlinks. Although those symlinks help the creation of releases and augment maintainability, they end up making the results of Trivy scans harder to comprehend.

## Exporting results in Security tab

One of the possible ouput formats from Trivy Scan is [SARIF](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning), allowing results to be uploaded to the Security Tab of the repository.
> The workflow also outputs the JSON format to the summary section of an action run.